### PR TITLE
Special processing of data conversion events

### DIFF
--- a/data-pipeline/bcreg/find-test-corps.py
+++ b/data-pipeline/bcreg/find-test-corps.py
@@ -128,6 +128,7 @@ specific_corps = [
                     'A0053723',
                     'A0082657',
                     '0319629',
+                    '0747962',
                     ]
 
 with BCRegistries() as bc_registries:

--- a/data-pipeline/bcreg/tests/bcreg_scenario_history_test.py
+++ b/data-pipeline/bcreg/tests/bcreg_scenario_history_test.py
@@ -57,18 +57,18 @@ def test_scenario_history_1():
     my_info = generate_info_for_corp(my_corp_dict)
     my_creds = generate_all_creds_for_corp(my_info)
 
-    assert len(my_creds) == 4
+    assert len(my_creds) == 3
 
-    assert my_creds[1]['cred_type'] == 'REG'
-    assert my_creds[1]['credential']['entity_status'] == 'ACT'
-    assert my_creds[1]['credential']['entity_type'] == 'A'
-    assert my_creds[1]['credential']['home_jurisdiction'] == 'ON'
-    assert my_creds[1]['credential']['registered_jurisdiction'] == 'BC'
-    assert my_creds[1]['credential']['registration_id'] == 'A0212812'
+    assert my_creds[0]['cred_type'] == 'REG'
+    assert my_creds[0]['credential']['entity_status'] == 'ACT'
+    assert my_creds[0]['credential']['entity_type'] == 'A'
+    assert my_creds[0]['credential']['home_jurisdiction'] == 'ON'
+    assert my_creds[0]['credential']['registered_jurisdiction'] == 'BC'
+    assert my_creds[0]['credential']['registration_id'] == 'A0212812'
 
-    assert my_creds[3]['cred_type'] == 'ADDR'
-    assert my_creds[3]['credential']['address_type'] == 'HD'
-    assert my_creds[3]['credential']['registration_id'] == 'A0212812'
+    assert my_creds[2]['cred_type'] == 'ADDR'
+    assert my_creds[2]['credential']['address_type'] == 'HD'
+    assert my_creds[2]['credential']['registration_id'] == 'A0212812'
 
 def test_scenario_history_2():
     my_corp_num = '5993202'

--- a/data-pipeline/bcreg/tests/bcreg_scenario_jurisdiction_test.py
+++ b/data-pipeline/bcreg/tests/bcreg_scenario_jurisdiction_test.py
@@ -64,19 +64,19 @@ def test_scenario_jurisdiction_man():
     my_creds = generate_creds_for_corp(my_corp_dict)
 
     print("# Home Jurisdiction United Kingdom (can_jur_typ_cd = ‘OT’ and othr_juris_desc = ‘GB’)")
-    assert len(my_creds) == 4
+    assert len(my_creds) == 3
 
-    assert my_creds[1]['cred_type'] == 'REG'
-    assert my_creds[1]['credential']['entity_status'] == 'ACT'
-    assert my_creds[1]['credential']['entity_type'] == 'A'
-    assert my_creds[1]['credential']['home_jurisdiction'] == 'GB'
-    assert my_creds[1]['credential']['registered_jurisdiction'] == 'BC'
-    assert my_creds[1]['credential']['registration_id'] == 'A5215485'
+    assert my_creds[0]['cred_type'] == 'REG'
+    assert my_creds[0]['credential']['entity_status'] == 'ACT'
+    assert my_creds[0]['credential']['entity_type'] == 'A'
+    assert my_creds[0]['credential']['home_jurisdiction'] == 'GB'
+    assert my_creds[0]['credential']['registered_jurisdiction'] == 'BC'
+    assert my_creds[0]['credential']['registration_id'] == 'A5215485'
 
-    assert my_creds[3]['cred_type'] == 'ADDR'
-    assert my_creds[3]['credential']['address_type'] == 'HD'
-    assert my_creds[3]['credential']['civic_address'] == 'GQACSKQWJZDWYJK D ITLV WW, UZNLSWYTMYQLUAJGDKDZWQZUV, ENGLAND  CW8 2YA, '
-    assert my_creds[3]['credential']['registration_id'] == 'A5215485'
+    assert my_creds[2]['cred_type'] == 'ADDR'
+    assert my_creds[2]['credential']['address_type'] == 'HD'
+    assert my_creds[2]['credential']['civic_address'] == 'GQACSKQWJZDWYJK D ITLV WW, UZNLSWYTMYQLUAJGDKDZWQZUV, ENGLAND  CW8 2YA, '
+    assert my_creds[2]['credential']['registration_id'] == 'A5215485'
 
 
 def test_scenario_jurisdiction_washington():
@@ -85,19 +85,19 @@ def test_scenario_jurisdiction_washington():
     my_creds = generate_creds_for_corp(my_corp_dict)
 
     print("# Home Jurisdiction Washington (can_jur_typ_cd = ‘OT’ and othr_juris_desc = ‘US, WA’)")
-    assert len(my_creds) == 3
+    assert len(my_creds) == 2
 
-    assert my_creds[1]['cred_type'] == 'REG'
-    assert my_creds[1]['credential']['entity_status'] == 'HIS'
-    assert my_creds[1]['credential']['entity_type'] == 'A'
-    assert my_creds[1]['credential']['home_jurisdiction'] == 'US, WA'
-    assert my_creds[1]['credential']['registered_jurisdiction'] == 'BC'
+    assert my_creds[0]['cred_type'] == 'REG'
+    assert my_creds[0]['credential']['entity_status'] == 'HIS'
+    assert my_creds[0]['credential']['entity_type'] == 'A'
+    assert my_creds[0]['credential']['home_jurisdiction'] == 'US, WA'
+    assert my_creds[0]['credential']['registered_jurisdiction'] == 'BC'
+    assert my_creds[0]['credential']['registration_id'] == 'A5462935'
+
+    assert my_creds[1]['cred_type'] == 'ADDR'
+    assert my_creds[1]['credential']['address_type'] == 'HD'
+    assert my_creds[1]['credential']['civic_address'] == 'XZVDZOLRCFHDHGGRTSJTLNLFY, VMUMZPQJWJJJPBPHKHLVNFIED, 98178, '
     assert my_creds[1]['credential']['registration_id'] == 'A5462935'
-
-    assert my_creds[2]['cred_type'] == 'ADDR'
-    assert my_creds[2]['credential']['address_type'] == 'HD'
-    assert my_creds[2]['credential']['civic_address'] == 'XZVDZOLRCFHDHGGRTSJTLNLFY, VMUMZPQJWJJJPBPHKHLVNFIED, 98178, '
-    assert my_creds[2]['credential']['registration_id'] == 'A5462935'
     
 
 def test_scenario_jurisdiction_uk():
@@ -106,19 +106,19 @@ def test_scenario_jurisdiction_uk():
     my_creds = generate_creds_for_corp(my_corp_dict)
 
     print("# Home Jurisdiction Federal (can_jur_typ_cd ‘FD’)")
-    assert len(my_creds) == 4
+    assert len(my_creds) == 3
 
-    assert my_creds[1]['cred_type'] == 'REG'
-    assert my_creds[1]['credential']['entity_status'] == 'ACT'
-    assert my_creds[1]['credential']['entity_type'] == 'A'
-    assert my_creds[1]['credential']['home_jurisdiction'] == 'FD'
-    assert my_creds[1]['credential']['registered_jurisdiction'] == 'BC'
-    assert my_creds[1]['credential']['registration_id'] == 'A4993014'
+    assert my_creds[0]['cred_type'] == 'REG'
+    assert my_creds[0]['credential']['entity_status'] == 'ACT'
+    assert my_creds[0]['credential']['entity_type'] == 'A'
+    assert my_creds[0]['credential']['home_jurisdiction'] == 'FD'
+    assert my_creds[0]['credential']['registered_jurisdiction'] == 'BC'
+    assert my_creds[0]['credential']['registration_id'] == 'A4993014'
 
-    assert my_creds[3]['cred_type'] == 'ADDR'
-    assert my_creds[3]['credential']['address_type'] == 'HD'
-    assert my_creds[3]['credential']['municipality'] == 'VANCOUVER'
-    assert my_creds[3]['credential']['registration_id'] == 'A4993014'
+    assert my_creds[2]['cred_type'] == 'ADDR'
+    assert my_creds[2]['credential']['address_type'] == 'HD'
+    assert my_creds[2]['credential']['municipality'] == 'VANCOUVER'
+    assert my_creds[2]['credential']['registration_id'] == 'A4993014'
     
 
 def test_scenario_jurisdiction_notonfile():
@@ -127,18 +127,18 @@ def test_scenario_jurisdiction_notonfile():
     my_creds = generate_creds_for_corp(my_corp_dict)
 
     print("# Home Jurisdiction Not on File (can_jur_typ_cd ‘OT’ and othr_juris_desc = null)")
-    assert len(my_creds) == 3
+    assert len(my_creds) == 2
 
-    assert my_creds[1]['cred_type'] == 'REG'
-    assert my_creds[1]['credential']['entity_status'] == 'HIS'
-    assert my_creds[1]['credential']['entity_type'] == 'A'
-    assert my_creds[1]['credential']['home_jurisdiction'] == 'OT'
-    assert my_creds[1]['credential']['registered_jurisdiction'] == 'BC'
+    assert my_creds[0]['cred_type'] == 'REG'
+    assert my_creds[0]['credential']['entity_status'] == 'HIS'
+    assert my_creds[0]['credential']['entity_type'] == 'A'
+    assert my_creds[0]['credential']['home_jurisdiction'] == 'OT'
+    assert my_creds[0]['credential']['registered_jurisdiction'] == 'BC'
+    assert my_creds[0]['credential']['registration_id'] == 'A9168630'
+
+    assert my_creds[1]['cred_type'] == 'ADDR'
+    assert my_creds[1]['credential']['address_type'] == 'HD'
     assert my_creds[1]['credential']['registration_id'] == 'A9168630'
-
-    assert my_creds[2]['cred_type'] == 'ADDR'
-    assert my_creds[2]['credential']['address_type'] == 'HD'
-    assert my_creds[2]['credential']['registration_id'] == 'A9168630'
     
 
 def test_scenario_jurisdiction_federal():

--- a/data-pipeline/bcreg/tests/bcreg_scenario_test.py
+++ b/data-pipeline/bcreg/tests/bcreg_scenario_test.py
@@ -137,11 +137,11 @@ def test_scenario_single_dba():
     my_creds = generate_creds_for_corp(my_corp_dict)
 
     print("# basic corp with 1 DBA (no DBA address)")
-    assert len(my_creds) == 6
+    assert len(my_creds) == 5
 
-    assert my_creds[1]['cred_type'] == 'REG'
-    assert my_creds[4]['cred_type'] == 'ADDR'
-    assert my_creds[5]['cred_type'] == 'REL'
+    assert my_creds[0]['cred_type'] == 'REG'
+    assert my_creds[3]['cred_type'] == 'ADDR'
+    assert my_creds[4]['cred_type'] == 'REL'
 
     my_dba_num = 'FM3035075'
     my_corp_dict['corp_num'] = my_dba_num
@@ -231,10 +231,10 @@ def test_scenario_empty_dates():
     my_creds = generate_creds_for_corp(my_corp_dict)
 
     print("# basic corp with empty dates")
-    assert len(my_creds) == 3
+    assert len(my_creds) == 2
 
-    assert my_creds[1]['cred_type'] == 'REG'
-    assert my_creds[2]['cred_type'] == 'ADDR'
+    assert my_creds[0]['cred_type'] == 'REG'
+    assert my_creds[1]['cred_type'] == 'ADDR'
 
 
 # utility method to process the selected corp and generate credentails


### PR DESCRIPTION
Ignore data conversion events per BC Reg:

Here is a review of the rules although we may have to also take into account all the PL/SQL at the beginning of this email. 

Ignore data that is missing, null, or 2004-03-26 

Calculation of name_date as you process corp_name rows and state_date as you process corp_state rows:

filing.effective_dt
conv_event.effective_dt
event.event_timestmp
if the start_event_id does not exist as an end_event_id for the same legal entity (creation event) then use corporation.recognition_dts
