### PR TITLE
Added rocket chat web hooks support for alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ genesis
 
 # Local config
 .env
-
+venv/
 
 # Ignore local Gradle files and folders
 .settings

--- a/bcreg-x/config/services.yml
+++ b/bcreg-x/config/services.yml
@@ -6,6 +6,7 @@ issuers:
       url_en: https://www2.gov.bc.ca/gov/content/governments/organizational-structure/ministries-organizations/ministries/citizens-services/bc-registries-online-services
       email: bcregistries@gov.bc.ca
       logo_path: ../assets/img/bcreg-logo-square.jpg
+      endpoint: $ENDPOINT_URL
 
     connection:
       type: OrgBook

--- a/data-pipeline/bcreg/bc_reg_pipeline_initial_load.py
+++ b/data-pipeline/bcreg/bc_reg_pipeline_initial_load.py
@@ -9,6 +9,7 @@ import data_integration.config
 from mara_app.monkey_patch import patch
 from bcreg.bcreg_pipelines import bc_reg_root_pipeline
 from bcreg.eventprocessor import EventProcessor
+from bcreg.rocketchat_hooks import log_error, log_warning, log_info
 
 
 patch(data_integration.config.system_statistics_collection_period)(lambda: 15)
@@ -23,18 +24,25 @@ mara_port = os.environ.get('MARA_DB_PORT', '5432')
 mara_user = os.environ.get('MARA_DB_USER', 'mara_db')
 mara_password = os.environ.get('MARA_DB_PASSWORD')
 
-mara_db.config.databases \
-    = lambda: {'mara': mara_db.dbs.PostgreSQLDB(user=mara_user, password=mara_password, host=mara_host, database=mara_database, port=mara_port)}
+try:
+    mara_db.config.databases \
+        = lambda: {'mara': mara_db.dbs.PostgreSQLDB(user=mara_user, password=mara_password, host=mara_host, database=mara_database, port=mara_port)}
 
-(initial_load_pipeline, success) = data_integration.pipelines.find_node(['initialization_and_load_tasks','bc_reg_corp_loader']) 
-if success:
-    corps_ct = 1
-    prev_corps_ct = 0
-    while 0 < corps_ct and corps_ct != prev_corps_ct:
-        # run at least once to get an initial data load
-        run_pipeline(initial_load_pipeline)
-        with EventProcessor() as eventprocessor:
-            prev_corps_ct = corps_ct
-            corps_ct = eventprocessor.get_outstanding_corps_record_count()
-else:
-    print("Pipeline not found")
+    (initial_load_pipeline, success) = data_integration.pipelines.find_node(['initialization_and_load_tasks','bc_reg_corp_loader']) 
+    if success:
+        corps_ct = 1
+        prev_corps_ct = 0
+        while 0 < corps_ct and corps_ct != prev_corps_ct:
+            # run at least once to get an initial data load
+            run_pipeline(initial_load_pipeline)
+            with EventProcessor() as eventprocessor:
+                prev_corps_ct = corps_ct
+                corps_ct = eventprocessor.get_outstanding_corps_record_count()
+            log_info("Ran bc_reg_corp_loader for " + str(corps_ct) + " corps")
+    else:
+        print("Pipeline not found")
+        log_error("Pipeline not found for:" + "bc_reg_corp_loader")
+except Exception as e:
+    print("Exception", e)
+    log_error("bc_reg_corp_loader processing exception: " + str(e))
+    raise

--- a/data-pipeline/bcreg/bc_reg_pipeline_post_credentials.py
+++ b/data-pipeline/bcreg/bc_reg_pipeline_post_credentials.py
@@ -9,6 +9,7 @@ import data_integration.config
 from mara_app.monkey_patch import patch
 from bcreg.bcreg_pipelines import bc_reg_root_pipeline
 from bcreg.eventprocessor import EventProcessor
+from bcreg.rocketchat_hooks import log_error, log_warning, log_info
 
 
 patch(data_integration.config.system_statistics_collection_period)(lambda: 15)
@@ -23,17 +24,24 @@ mara_port = os.environ.get('MARA_DB_PORT', '5432')
 mara_user = os.environ.get('MARA_DB_USER', 'mara_db')
 mara_password = os.environ.get('MARA_DB_PASSWORD')
 
-mara_db.config.databases \
-    = lambda: {'mara': mara_db.dbs.PostgreSQLDB(user=mara_user, password=mara_password, host=mara_host, database=mara_database, port=mara_port)}
+try:
+    mara_db.config.databases \
+        = lambda: {'mara': mara_db.dbs.PostgreSQLDB(user=mara_user, password=mara_password, host=mara_host, database=mara_database, port=mara_port)}
 
-(post_credential_pipeline, success) = data_integration.pipelines.find_node(['initialization_and_load_tasks','bc_reg_credential_poster']) 
-if success:
-	creds_ct = 0
-	with EventProcessor() as eventprocessor:
-		creds_ct = eventprocessor.get_outstanding_creds_record_count()
-	while 0 < creds_ct:
-		run_pipeline(post_credential_pipeline)
-		with EventProcessor() as eventprocessor:
-			creds_ct = eventprocessor.get_outstanding_creds_record_count()
-else:
-	print("Pipeline not found")
+    (post_credential_pipeline, success) = data_integration.pipelines.find_node(['initialization_and_load_tasks','bc_reg_credential_poster']) 
+    if success:
+        creds_ct = 0
+        with EventProcessor() as eventprocessor:
+            creds_ct = eventprocessor.get_outstanding_creds_record_count()
+        while 0 < creds_ct:
+            run_pipeline(post_credential_pipeline)
+            with EventProcessor() as eventprocessor:
+                creds_ct = eventprocessor.get_outstanding_creds_record_count()
+            log_info("Ran bc_reg_credential_poster for " + str(corps_ct) + " corps")
+    else:
+        print("Pipeline not found")
+        log_error("Pipeline not found for:" + "bc_reg_credential_poster")
+except Exception as e:
+    print("Exception", e)
+    log_error("bc_reg_credential_poster processing exception: " + str(e))
+    raise

--- a/data-pipeline/bcreg/bc_reg_pipeline_post_credentials.py
+++ b/data-pipeline/bcreg/bc_reg_pipeline_post_credentials.py
@@ -37,7 +37,7 @@ try:
             run_pipeline(post_credential_pipeline)
             with EventProcessor() as eventprocessor:
                 creds_ct = eventprocessor.get_outstanding_creds_record_count()
-            log_info("Ran bc_reg_credential_poster for " + str(corps_ct) + " corps")
+            log_info("Ran bc_reg_credential_poster for " + str(creds_ct) + " corps")
     else:
         print("Pipeline not found")
         log_error("Pipeline not found for:" + "bc_reg_credential_poster")

--- a/data-pipeline/bcreg/find-unprocessed-events.py
+++ b/data-pipeline/bcreg/find-unprocessed-events.py
@@ -4,31 +4,42 @@ import datetime
 from bcreg.config import config
 from bcreg.eventprocessor import EventProcessor
 from bcreg.bcregistries import BCRegistries, system_type
+from bcreg.rocketchat_hooks import log_error, log_warning, log_info
 
+MAX_CORPS = 10000
 
-with BCRegistries() as bc_registries:
-    with EventProcessor() as event_processor:
-        print("Get last processed event")
-        prev_event_date = event_processor.get_last_processed_event_date(system_type)
-        if prev_event_date is not None:
-            prev_event_id = event_processor.get_last_processed_event(prev_event_date, system_type)
-        else:
-            prev_event_id = 0
-        
-        print("Get last max event")
-        max_event_date = bc_registries.get_max_event_date()
-        max_event_id = bc_registries.get_max_event(max_event_date)
-        
-        # get unprocessed corps (there are about 2700)
-        print("Get unprocessed corps")
-        last_event_dt = bc_registries.get_event_effective_date(prev_event_id)
-        max_event_dt = bc_registries.get_event_effective_date(max_event_id)
-        corps = bc_registries.get_unprocessed_corps(prev_event_id, last_event_dt, max_event_id, max_event_dt)
-        
-        print("Find unprocessed events for each corp")
-        corps = bc_registries.get_unprocessed_corp_events(prev_event_id, last_event_dt, max_event_id, max_event_dt, corps)
-        
-        print("Update our queue")
-        event_processor.update_corp_event_queue(system_type, corps, max_event_id, max_event_date)
+try:
+    with BCRegistries() as bc_registries:
+        with EventProcessor() as event_processor:
+            print("Get last processed event")
+            prev_event_date = event_processor.get_last_processed_event_date(system_type)
+            if prev_event_date is not None:
+                prev_event_id = event_processor.get_last_processed_event(prev_event_date, system_type)
+            else:
+                prev_event_id = 0
+            
+            print("Get last max event")
+            max_event_date = bc_registries.get_max_event_date()
+            max_event_id = bc_registries.get_max_event(max_event_date)
+            
+            # get unprocessed corps (there are about 2700)
+            print("Get unprocessed corps")
+            last_event_dt = bc_registries.get_event_effective_date(prev_event_id)
+            max_event_dt = bc_registries.get_event_effective_date(max_event_id)
+            corps = bc_registries.get_unprocessed_corps(prev_event_id, last_event_dt, max_event_id, max_event_dt)
+            
+            print("Find unprocessed events for each corp")
+            corps = bc_registries.get_unprocessed_corp_events(prev_event_id, last_event_dt, max_event_id, max_event_dt, corps)
+
+            # reasonability test on the number of outstanding records
+            if MAX_CORPS < len(corps):
+                log_warning("find-unpocessed-events More than max corps: " + str(len(corps)))
+            
+            print("Update our queue")
+            event_processor.update_corp_event_queue(system_type, corps, max_event_id, max_event_date)
+except Exception as e:
+    print("Exception", e)
+    log_error("find-unpocessed-events processing exception: " + str(e))
+    raise
 
 

--- a/data-pipeline/bcreg/generate-creds.py
+++ b/data-pipeline/bcreg/generate-creds.py
@@ -5,8 +5,14 @@ from bcreg.config import config
 from bcreg.eventprocessor import EventProcessor
 from bcreg.bcregistries import BCRegistries, system_type
 from bcreg.eventprocessor import EventProcessor
+from bcreg.rocketchat_hooks import log_error, log_warning, log_info
 
 
-with EventProcessor() as event_processor:
-	event_processor.process_corp_generate_creds()
+try:
+    with EventProcessor() as event_processor:
+    	event_processor.process_corp_generate_creds()
+except Exception as e:
+    print("Exception", e)
+    log_error("generate_creds processing exception: " + str(e))
+    raise
 

--- a/data-pipeline/bcreg/process-corps-generate-creds.py
+++ b/data-pipeline/bcreg/process-corps-generate-creds.py
@@ -5,9 +5,15 @@ import json
 import decimal
 from bcreg.config import config
 from bcreg.eventprocessor import EventProcessor
+from bcreg.rocketchat_hooks import log_error, log_warning, log_info
 
 
-with EventProcessor() as event_processor:
-    event_processor.process_corp_event_queue_and_generate_creds(True)
+try:
+    with EventProcessor() as event_processor:
+        event_processor.process_corp_event_queue_and_generate_creds(True)
+except Exception as e:
+    print("Exception", e)
+    log_error("process_corps_generate_creds processing exception: " + str(e))
+    raise
 
 

--- a/data-pipeline/bcreg/rocketchat_hooks.py
+++ b/data-pipeline/bcreg/rocketchat_hooks.py
@@ -1,0 +1,75 @@
+from os import environ
+import asyncio
+import aiohttp
+
+import time
+import datetime
+
+import json
+
+
+LOG_LEVELS = {
+    '0': 'ERROR',
+    '1': 'WARNING',
+    '2': 'INFO'
+}
+
+log_level = environ.get('WEBHOOK_LEVEL', '0')
+if log_level > '2':
+    log_level = '2'
+elif log_level < '0':
+    log_level = '0'
+
+webhook_url = environ.get('WEBHOOK_URL', '')
+
+
+def get_webhook_payload(level, message):
+    project_name = environ.get('PROJECT_NAME', "von-bc-registries-agent")
+    friendly_project_name = environ.get('FRIENDLY_PROJECT_NAME', "BC Registries")
+    payload = {
+        "friendlyProjectName": friendly_project_name,
+        "projectName": project_name,
+        "statusCode": LOG_LEVELS[level],
+        "message": message
+    }
+    #payload = json.dumps(payload)
+    return payload
+
+
+async def _post_url(the_url, payload):
+    async with aiohttp.ClientSession() as session:
+        headers = {'Content-Type': 'application/json'}
+        async with session.post(the_url, json=payload, headers=headers) as resp:
+            r_status = resp.status
+            r_text = await resp.text()
+            return (r_status, r_text)
+
+
+def run_coroutine_with_args(coroutine, *args):
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        return loop.run_until_complete(coroutine(*args))
+    finally:
+        loop.close()
+
+
+def post_msg_to_webhook(level, message):
+    if webhook_url and 0 < len(webhook_url):
+        if level and level <= log_level:
+            payload = get_webhook_payload(level, message)
+            (status, text) = run_coroutine_with_args(_post_url, webhook_url, payload)
+
+
+def log_info(message):
+    post_msg_to_webhook('2', message)
+
+
+def log_warning(message):
+    post_msg_to_webhook('1', message)
+
+
+def log_error(message):
+    post_msg_to_webhook('0', message)
+
+

--- a/data-pipeline/bcreg/submit-creds.py
+++ b/data-pipeline/bcreg/submit-creds.py
@@ -18,9 +18,15 @@
 
 import asyncio
 from bcreg.credssubmitter import CredsSubmitter
+from bcreg.rocketchat_hooks import log_error, log_warning, log_info
 
 
-loop = asyncio.get_event_loop()
-with CredsSubmitter() as creds_submitter:
-    loop.run_until_complete(creds_submitter.process_credential_queue(False))
+try:
+    loop = asyncio.get_event_loop()
+    with CredsSubmitter() as creds_submitter:
+        loop.run_until_complete(creds_submitter.process_credential_queue(False))
+except Exception as e:
+    print("Exception", e)
+    log_error("submit_creds processing exception: " + str(e))
+    raise
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       dockerfile: Dockerfile
     environment:
       APPLICATION_URL: ${APPLICATION_URL:-http://localhost:5000}
+      ENDPOINT_URL: ${ENDPOINT_URL:-http://localhost:5001}
       CONFIG_ROOT: ../config
       ENVIRONMENT: ${ENVIRONMENT:-default}
       ENABLE_GUNICORN: ${ENABLE_GUNICORN:-0}
@@ -64,6 +65,12 @@ services:
       context: ../data-pipeline
       dockerfile: docker/mara-app/Dockerfile
     environment:
+      # web hooks
+      - ENVIRONMENT=${ENVIRONMENT:-default}
+      - WEBHOOK_URL=${WEBHOOK_URL}
+      - WEBHOOK_LEVEL=${WEBHOOK_LEVEL:-0}  # 0=Error, 1=Warning, 2=Info
+      - PROJECT_NAME=${PROJECT_NAME:-von-bc-registries-agent}
+      - FRIENDLY_PROJECT_NAME=${FRIENDLY_PROJECT_NAME:-BC Registries Data Pipeline}
       - VONX_API_URL=${VONX_API_URL:-http://bcreg-agent:8000/bcreg}
       # [bc_registries]
       - BC_REG_DB_HOST=${BC_REG_DB_HOST:-host.docker.internal}

--- a/docker/manage
+++ b/docker/manage
@@ -88,7 +88,7 @@ configureEnvironment () {
   export COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-"vonx"}
   export LEDGER_URL=${LEDGER_URL-http://$DOCKERHOST:9000}
   export APPLICATION_URL=${APPLICATION_URL-http://localhost:${WEB_HTTP_PORT:-5000}}
-
+  export ENDPOINT_URL=http://${ENDPOINT_HOST-$DOCKERHOST:${WEB_HTTP_PORT:-5001}}
 
   # wallet-db
   export POSTGRESQL_DATABASE="THE_ORG_BOOK"

--- a/scripts/rocket.chat.integration.js
+++ b/scripts/rocket.chat.integration.js
@@ -1,0 +1,50 @@
+class Script {
+  /**
+   * @params {object} request
+   */
+  process_incoming_request({ request }) {
+    let data = request.content;
+    let attachmentColor = `#36A64F`;
+    let statusMsg = `Status`;
+    let isError = data.statusCode === `ERROR`;
+    if (isError) {
+      statusMsg = `Error`;
+      attachmentColor = `#A63636`;
+    }
+
+    let friendlyProjectName=``;
+    if(data.projectFriendlyName) {
+      friendlyProjectName = data.projectFriendlyName
+    }
+
+    let projectName=``;
+    if (data.projectName) {
+      projectName = data.projectName
+      if(!friendlyProjectName) {
+        friendlyProjectName = projectName
+      }
+    }
+
+    if(projectName) {
+      statusMsg += ` message received from [${friendlyProjectName}](https://console.pathfinder.gov.bc.ca:8443/console/project/${projectName}/overview):`;
+    } else {
+      statusMsg += ` message received:`;
+    }
+
+    if (isError) {
+      statusMsg = `**${statusMsg}**`;
+    }
+
+    return {
+      content:{
+        text: statusMsg,
+        attachments: [
+          {
+            text: `${data.message}`,
+            color: attachmentColor
+          }
+        ]
+      }
+    };
+  }
+}


### PR DESCRIPTION
Added support for sending alerts to rocket chat, and added alerts to several data pipeline jobs.

There are 3 levels - Error, Warning, Info - to control the amount of info displayed in rocket chat.

Environment variables required are:

WEBHOOK_URL - url for the rocket chat hook - if not provided, no hooks are sent
WEBHOOK_LEVEL - 0 (Error), 1 (Warning) or 2 (Info) - hooks are posted to rocket chat based on the level (e.g. if level is set to Warning, then Errors and Warnings will be hooked but not Info)
PROJECT_NAME - as it exists in OpenShift (used to create the link in the message)
FRIENDLY_PROJECT_NAME - project name as displayed to humans

Rocket chat script is included (to parse received json messages)
