### PR TITLE
Fix sql logic; fix edge case in ADMIN events

### DIFF
--- a/data-pipeline/bcreg/eventprocessor.py
+++ b/data-pipeline/bcreg/eventprocessor.py
@@ -752,7 +752,7 @@ class EventProcessor:
                                                                 corp_cred['cred_type'], corp_cred['id'], corp_cred['schema'], corp_cred['version'], 
                                                                 corp_cred['credential'], corp_cred['credential_reason'])
             else:
-                LOGGER.error("Error can't issue a credential with no effective date!")
+                LOGGER.error("Error can't issue a credential with no effective date! " + corp_num + " " + corp_cred['cred_type'] + " " + str(corp_cred))
         return cred_count
 
     def build_credential_dict(self, cred_type, schema, version, cred_id, credential, credential_reason, effective_date):
@@ -1230,7 +1230,7 @@ class EventProcessor:
                     dba_cred['effective_date'] = party['effective_start_date']
 
                     # if the start event is 'ADMIN' type and there is only one party record, use the firm effective date
-                    if party['start_event']['event_typ_cd'] == 'ADMIN' and party_count[party['corp_info']['corp_num']] == 1:
+                    if party['start_event']['event_typ_cd'] == 'ADMIN' and party_count[party['corp_info']['corp_num']] == 1 and party['corp_info']['recognition_dts']:
                         dba_cred['effective_date'] = party['corp_info']['recognition_dts']
 
                     dba_cred['relationship_status_effective'] = self.filter_min_date(dba_cred['effective_date'])

--- a/data-pipeline/bcreg/populate_audit_table.py
+++ b/data-pipeline/bcreg/populate_audit_table.py
@@ -26,7 +26,9 @@ To force re-process of these companies, run the following sql's:
     set process_success = null, process_date = null, process_msg = null
     where process_success is not null
     and corp_num in
-    (select corp_num from CORP_AUDIT_LOG where LAST_CREDENTIAL_ID is null);
+    (select corp_num from CORP_AUDIT_LOG where LAST_CREDENTIAL_ID is null)
+    and corp_num not in
+    (select corp_num from corp_history_log where process_msg = 'Withdrawn');
 
     commit;
 
@@ -37,7 +39,9 @@ Or to insert new records to re-process the entire company history:
     select 'BC_REG', corp_num, 0, '0001-01-01 00:00:00', event_id, event_date, now()
     from CORP_AUDIT_LOG, LAST_EVENT
     where CORP_AUDIT_LOG.last_credential_id is null
-      and LAST_EVENT.record_id = (select max(record_id) from LAST_EVENT);
+      and LAST_EVENT.record_id = (select max(record_id) from LAST_EVENT)
+      and corp_num not in
+      (select corp_num from corp_history_log where process_msg = 'Withdrawn');
 
     commit;
 

--- a/data-pipeline/bcreg/requeue-missing-rel.sql
+++ b/data-pipeline/bcreg/requeue-missing-rel.sql
@@ -23,6 +23,8 @@ from credential_log
 where credential_type_cd = 'REL') as foo
 on c_log.credential_json->>'registration_id' = foo.associated_registration_id
 and c_log.credential_json->>'associated_registration_id' = foo.registration_id
-where c_log.corp_num is null or foo.corp_num is null) as MISSING_CORP_RELN, 
+where c_log.corp_num is null or foo.corp_num is null
+  and c_log.corp_num not in
+  (select corp_num from corp_history_log where process_msg = 'Withdrawn')) as MISSING_CORP_RELN, 
   LAST_EVENT
 where LAST_EVENT.record_id = (select max(record_id) from LAST_EVENT);


### PR DESCRIPTION
Signed-off-by: Ian Costanzo <ian@anon-solutions.ca>

Fix SQL logic to exclude "withdrawn" companies.

Fix edge case in ADMIN events that were losing the "effective date" of generated credentials.
