### PR TITLE
Add timeout to credential posting, and limit batch size

### DIFF
--- a/data-pipeline/bcreg/credssubmitter.py
+++ b/data-pipeline/bcreg/credssubmitter.py
@@ -42,6 +42,9 @@ MAX_PROCESSING_MINS = int(os.getenv('MAX_PROCESSING_MINS', '10'))
 # how often to report status (# credentials)
 PROCESS_LOOP_REPORT_CT = int(os.getenv('PROCESS_LOOP_REPORT_CT', '100'))
 
+# seconds to wait for a credential response (prevents blocking forever)
+MAX_CRED_POSTING_TIMEOUT = int(os.getenv('MAX_CRED_POSTING_TIMEOUT', '240'))
+
 MAX_CORPS = 10000
 CRAZY_MAX_CORPS = 100000
 
@@ -60,10 +63,10 @@ def notify_error(message):
 async def submit_cred_batch(http_client, creds):
     try:
         #print("Posting to:", '{}/issue-credential'.format(AGENT_URL))
-        response = await http_client.post(
+        response = await asyncio.wait_for(http_client.post(
             '{}/issue-credential'.format(AGENT_URL),
             json=creds
-        )
+        ), timeout=MAX_CRED_POSTING_TIMEOUT)
         if response.status != 200:
             raise RuntimeError(
                 'Credentials could not be processed: {}'.format(await response.text())
@@ -325,7 +328,8 @@ class CredsSubmitter:
                         max_rec_id = row[0]
 
                     # make sure to include all credentials for the same client id within the same batch
-                    if CREDS_REQUEST_SIZE <= len(credentials) and credential['CORP_NUM'] != cred_owner_id:
+                    # but also - limit batch size to avoid timeouts
+                    if (CREDS_REQUEST_SIZE <= len(credentials) and credential['CORP_NUM'] != cred_owner_id) or (len(credentials) >= 2*CREDS_REQUEST_SIZE):
                         post_creds = credentials.copy()
                         creds_task = loop.create_task(post_credentials(http_client, self.conn, post_creds))
                         tasks.append(creds_task)


### PR DESCRIPTION
Signed-off-by: Ian Costanzo <ian@anon-solutions.ca>

Added a new parameter MAX_CRED_POSTING_TIMEOUT to specify a timeout on the credential posting (to issuer controller)

Also put a hard limit on the batch size sent to issuer controller.
