### PR TITLE
Fix startup issue with latest postgres image

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -170,9 +170,9 @@ services:
       context: ../data-pipeline
       dockerfile: docker/postgres/Dockerfile
     environment:
-      - POSTGRESQL_USER=${POSTGRESQL_USER}
-      - POSTGRESQL_PASSWORD=${POSTGRESQL_PASSWORD}
-      - POSTGRESQL_DATABASE=${POSTGRESQL_DATABASE}
+      - POSTGRES_USER=${POSTGRESQL_USER}
+      - POSTGRES_PASSWORD=${POSTGRESQL_PASSWORD}
+      - POSTGRES_DATABASE=${POSTGRESQL_DATABASE}
     networks:
       - orgbook
     ports:


### PR DESCRIPTION
- Environment variables used to define the username. password, and database name have changed.
- Note this affects the official [Postgres](https://hub.docker.com/_/postgres) image, not the rhel version of the Postgres

Signed-off-by: Wade Barnes <wade.barnes@shaw.ca>