### PR TITLE
Updates to support Business Number credential

### DIFF
--- a/bcreg-aca/config/schemas.yml
+++ b/bcreg-aca/config/schemas.yml
@@ -177,11 +177,9 @@
       description_en: Reason for credential issue/update
       required: false
 
-- name: demo.business_number.registries.ca
+- name: business_number.registries.ca
   version: '1.0.42'
-  description: TODO
-  cardinality:
-    - business_number
+  description: Business Number credential
   attributes:
     registration_id:
       label_en: Registration ID

--- a/bcreg-aca/config/services.yml
+++ b/bcreg-aca/config/services.yml
@@ -308,7 +308,7 @@ issuers:
                 input: reason_description
                 from: claim
 
-      - schema: demo.business_number.registries.ca
+      - schema: business_number.registries.ca
         issuer_url: $APPLICATION_URL_ADDRESS
         description: TODO
         details:

--- a/bcreg-aca/config/services.yml
+++ b/bcreg-aca/config/services.yml
@@ -328,13 +328,14 @@ issuers:
           type:
             input: registration.registries.ca
             from: value
-        cardinality_fields:
-          - business_number
         mapping:
           - model: attribute
             fields:
               type:
                 input: business_number
+                from: value
+              format:
+                input: category
                 from: value
               value:
                 input: business_number

--- a/bcreg-aca/src/issuer.py
+++ b/bcreg-aca/src/issuer.py
@@ -297,7 +297,7 @@ class StartupProcessingThread(threading.Thread):
                     schema_info = app_config["schemas"]["SCHEMA_" + schema_name]
                     ctype_config = {
                         "schema_name": schema_name,
-                        "schema_version": schema_version,
+                        "schema_version": schema_info["version"],
                         "issuer_url": issuer_config["url"],
                         "config_root": config_root,
                         "credential_def_id": app_config["schemas"][

--- a/data-pipeline/bcreg/bc_reg_bn_cred_pipeline.py
+++ b/data-pipeline/bcreg/bc_reg_bn_cred_pipeline.py
@@ -1,0 +1,47 @@
+import os
+from data_integration.pipelines import Pipeline, Task
+from data_integration.ui.cli import run_pipeline
+import mara_db.auto_migration
+import mara_db.config
+import mara_db.dbs
+import data_integration
+import data_integration.config
+import logging
+
+from mara_app.monkey_patch import patch
+from bcreg.bcreg_pipelines import bc_reg_root_pipeline
+from bcreg.eventprocessor import EventProcessor
+from bcreg.rocketchat_hooks import log_error, log_warning, log_info
+
+LOG_LEVEL = os.environ.get('LOG_LEVEL', 'WARNING').upper()
+logging.basicConfig(level=LOG_LEVEL)
+
+
+patch(data_integration.config.system_statistics_collection_period)(lambda: 15)
+
+@patch(data_integration.config.root_pipeline)
+def root_pipeline():
+    return bc_reg_root_pipeline()
+
+mara_host = os.environ.get('MARA_DB_HOST', 'bcregdb')
+mara_database = os.environ.get('MARA_DB_DATABASE', 'mara_db')
+mara_port = os.environ.get('MARA_DB_PORT', '5432')
+mara_user = os.environ.get('MARA_DB_USER', 'mara_db')
+mara_password = os.environ.get('MARA_DB_PASSWORD')
+
+try:
+    log_info("Starting bc_reg_bn_loader ...")
+    mara_db.config.databases \
+        = lambda: {'mara': mara_db.dbs.PostgreSQLDB(user=mara_user, password=mara_password, host=mara_host, database=mara_database, port=mara_port)}
+
+    (child_pipeline, success) = data_integration.pipelines.find_node(['initialization_and_load_tasks', 'bc_reg_bn_loader']) 
+    if success:
+        run_pipeline(child_pipeline)
+        log_info("Ran bc_reg_bn_loader - complete.")
+    else:
+        print("Pipeline not found")
+        log_error("Pipeline not found for:" + "bc_reg_bn_loader")
+except Exception as e:
+    print("Exception", e)
+    log_error("bc_reg_bn_loader processing exception: " + str(e))
+    raise

--- a/data-pipeline/bcreg/bcreg_pipelines.py
+++ b/data-pipeline/bcreg/bcreg_pipelines.py
@@ -19,6 +19,7 @@ def bc_reg_root_pipeline():
     init_pipeline.add(bc_reg_pipeline_initial_load())
     init_pipeline.add(bc_reg_pipeline_post_credentials())
     init_pipeline.add(bc_reg_populate_audit_table())
+    init_pipeline.add(bc_reg_pipeline_bn_credential_load())
 
     parent_pipeline.add(init_pipeline)
 
@@ -96,6 +97,22 @@ def bc_reg_pipeline_initial_load():
                           commands=[ExecutePython('./bcreg/find-unprocessed-corps_actve.py')]))
     sub_pipeline1_2.add(Task(id='load_bc_reg_data_a', description='Load BC Registries data',
                           commands=[ExecutePython('./bcreg/process-corps-generate-creds.py')]), ['register_un_processed_corps'])
+    pipeline1.add(sub_pipeline1_2)
+
+    return pipeline1
+
+def bc_reg_pipeline_bn_credential_load():
+    import bcreg
+
+    pipeline1 = Pipeline(
+        id='bc_reg_bn_loader',
+        description='A pipeline that creates BN credentials for all existing corporations.')
+
+    sub_pipeline1_2 = Pipeline(id='load_existing_corps_no_bn', description='Load BC Reg corps with no BN credential')
+    sub_pipeline1_2.add(Task(id='register_un_bned_corps', description='Register corps with no BN',
+                          commands=[ExecutePython('./bcreg/find-un-bned-corps.py')]))
+    sub_pipeline1_2.add(Task(id='load_corp_bn_data', description='Load BN credentials from company data',
+                          commands=[ExecutePython('./bcreg/process-corps-generate-bn-creds.py')]), ['register_un_bned_corps'])
     pipeline1.add(sub_pipeline1_2)
 
     return pipeline1

--- a/data-pipeline/bcreg/eventprocessor.py
+++ b/data-pipeline/bcreg/eventprocessor.py
@@ -1209,6 +1209,32 @@ class EventProcessor:
 
         return (vp_reg_id, vp_fn, vp_ln, vp_email, vp_phone)
 
+    def generate_bn_credential(self, system_typ_cd, corp_num, corp_info):
+        """Generate a BN credential."""
+        # generate a BN credential if the corp has a BN
+        if "bn_9" in corp_info and corp_info["bn_9"] and 0 < len(corp_info["bn_9"]):
+            #print(">>> generate a bn credential for", corp_num, corp_info["bn_9"])
+            bn_cred = {}
+            bn_cred["registration_id"] = self.corp_num_with_prefix(corp_info['corp_typ_cd'], corp_info['corp_num'])
+            bn_cred["business_number"] = corp_info["bn_9"]
+            bn_cred["effective_date"] = corp_info["recognition_dts"]
+            bn_cred["expiry_date"] = ""
+            return self.build_credential_dict(bn_credential, bn_schema, bn_version, bn_cred['registration_id'], bn_cred, '', bn_cred['effective_date'])
+
+        return None
+
+    def generate_credentials_of_type(self, system_typ_cd, credential_type_cd, corp_num, corp_info):
+        """Generate credentials only of the specified type."""
+        corp_creds = []
+        if credential_type_cd == bn_credential:
+            bn_cred = self.generate_bn_credential(system_typ_cd, corp_num, corp_info)
+            if bn_cred:
+                corp_creds.append(bn_cred)
+        else:
+            raise Exception("Error credential type not supported: " + credential_type_cd)
+
+        return corp_creds
+
     # generate credentials for the provided corp
     def generate_credentials(self, system_typ_cd, prev_event, last_event, corp_num, corp_info):
         """
@@ -1444,14 +1470,9 @@ class EventProcessor:
                     corp_creds.append(self.build_credential_dict(dba_credential, dba_schema, dba_version, dba_cred['registration_id'], dba_cred, reason_description, dba_cred['effective_date']))
 
         # generate a BN credential if the corp has a BN
-        if "bn_9" in corp_info and corp_info["bn_9"] and 0 < len(corp_info["bn_9"]):
-            #print(">>> generate a bn credential for", corp_num, corp_info["bn_9"])
-            bn_cred = {}
-            bn_cred["registration_id"] = self.corp_num_with_prefix(corp_info['corp_typ_cd'], corp_info['corp_num'])
-            bn_cred["business_number"] = corp_info["bn_9"]
-            bn_cred["effective_date"] = corp_info["recognition_dts"]
-            bn_cred["expiry_date"] = ""
-            corp_creds.append(self.build_credential_dict(bn_credential, bn_schema, bn_version, bn_cred['registration_id'], bn_cred, '', bn_cred['effective_date']))
+        #bn_cred = self.generate_bn_credential(system_typ_cd, corp_num, corp_info)
+        #if bn_cred:
+        #    corp_creds.append(bn_cred)
 
         if GENERATE_EXTRA_DEMO_CREDS:
             # DEMO generate Verified Individual credentials and relationships (2 way)
@@ -1860,6 +1881,91 @@ class EventProcessor:
         Credentials are submitted to TOB via the agent using a separate process.
         """
         self.process_corp_event_queue_internal(True, True, use_cache)
+
+    def generate_credential_type(self, system_type, credential_typ_cd):
+        """Generate credentials of the requested type for all queued orgs."""
+        sql1 = """SELECT repo.record_id, repo.system_type_cd, repo.corp_history_id, repo.credential_type_cd,
+                         repo.corp_num, hist.corp_state, hist.corp_json, hist.prev_event, hist.last_event
+                  FROM corp_cred_reprocess_log repo, corp_history_log hist
+                  WHERE repo.process_success is null
+                    AND hist.record_id = repo.corp_history_id
+                  LIMIT !BS!;"""
+
+        sql3a = """UPDATE corp_cred_reprocess_log
+                  SET PROCESS_DATE = %s, PROCESS_SUCCESS = %s, PROCESS_MSG = %s
+                  WHERE RECORD_ID = %s"""
+
+        print("Generating credentials for", system_type, credential_typ_cd, "...")
+        cur = None
+        try:
+            # we are loading data from BC Registries based on the corp event queue
+            # sql1 = find unprocessed events from our local table EVENT_BY_CORP_FILING
+            corps = []
+            cur = self.conn.cursor()
+            cur.execute(sql1.replace("!BS!", str(CORP_BATCH_SIZE)))
+            row = cur.fetchone()
+            while row is not None:
+                # include the date(s) for the start and end events
+                corp = {'RECORD_ID':row[0], 'SYSTEM_TYPE_CD':row[1], 'CORP_HISTORY_ID':row[2], 'CREDENTIAL_TYPE_CD':row[3],
+                                'CORP_NUM':row[4], 'CORP_STATE':row[5], 'CORP_JSON':row[6], 'PREV_EVENT':row[7], 'LAST_EVENT':row[8]}
+                corps.append(corp)
+                row = cur.fetchone()
+            cur.close()
+            cur = None
+
+            print("Processing " + str(len(corps)) + " orgs for credential " + system_type + " " + credential_typ_cd)
+            saved_creds = 0
+            for corp in corps:
+                corp_creds = []
+                process_success = True
+                try:
+                    # generate and store credentials
+                    corp_creds = self.generate_credentials_of_type(corp['SYSTEM_TYPE_CD'], corp['CREDENTIAL_TYPE_CD'], corp['CORP_NUM'], corp['CORP_JSON'])
+                    if len(corp_creds) > 0:
+                        cur = self.conn.cursor()
+                        saved_creds = saved_creds + self.store_credentials(cur, corp['SYSTEM_TYPE_CD'], corp['PREV_EVENT'], corp['LAST_EVENT'], 
+                                                corp['CORP_NUM'], corp['CORP_STATE'], corp['CORP_JSON'], corp_creds)
+                        cur.close()
+                        cur = None
+                except (Exception, psycopg2.DatabaseError) as error:
+                    print(error)
+                    LOGGER.error(error)
+                    LOGGER.error(traceback.print_exc())
+                    process_success = False
+                    process_msg = str(error)
+                    #raise
+                finally:
+                    if cur is not None:
+                        cur.close()
+
+                # store corporate info 
+                if process_success:
+                    flag = 'Y'
+                    res = None
+                else:
+                    flag = 'N'
+                    if 255 < len(process_msg):
+                        res = process_msg[:250] + '...'
+                    else:
+                        res = process_msg
+
+                # update process date
+                cur = self.conn.cursor()
+                cur.execute(sql3a, (datetime.datetime.now(), flag, res, corp['RECORD_ID'], ))
+                if flag == 'N':
+                    log_warning('Event processing error:' + res)
+                self.conn.commit()
+                cur.close()
+                cur = None
+
+        except (Exception, psycopg2.DatabaseError) as error:
+            LOGGER.error(error)
+            LOGGER.error(traceback.print_exc())
+            log_error("EventProcessor exception updating DB: " + str(error))
+            raise
+        finally:
+            if cur is not None:
+                cur.close()
 
     def queue_reprocess_credential_type(self, system_type, credential_typ_cd):
         """Queue up all existing orgs to process a credential of a specific type."""

--- a/data-pipeline/bcreg/eventprocessor.py
+++ b/data-pipeline/bcreg/eventprocessor.py
@@ -1470,9 +1470,9 @@ class EventProcessor:
                     corp_creds.append(self.build_credential_dict(dba_credential, dba_schema, dba_version, dba_cred['registration_id'], dba_cred, reason_description, dba_cred['effective_date']))
 
         # generate a BN credential if the corp has a BN
-        #bn_cred = self.generate_bn_credential(system_typ_cd, corp_num, corp_info)
-        #if bn_cred:
-        #    corp_creds.append(bn_cred)
+        bn_cred = self.generate_bn_credential(system_typ_cd, corp_num, corp_info)
+        if bn_cred:
+            corp_creds.append(bn_cred)
 
         if GENERATE_EXTRA_DEMO_CREDS:
             # DEMO generate Verified Individual credentials and relationships (2 way)

--- a/data-pipeline/bcreg/eventprocessor.py
+++ b/data-pipeline/bcreg/eventprocessor.py
@@ -48,7 +48,7 @@ dba_version = '1.0.42'
 
 # the next 4 cred types will only be generated in "demo" mode
 bn_credential = 'BNC'
-bn_schema = 'demo.business_number.registries.ca'
+bn_schema = 'business_number.registries.ca'
 bn_version = '1.0.42'
 
 vp_credential = 'VPC'
@@ -1386,17 +1386,17 @@ class EventProcessor:
                     reason_description = self.build_corp_reason_code(party['start_event'])
                     corp_creds.append(self.build_credential_dict(dba_credential, dba_schema, dba_version, dba_cred['registration_id'], dba_cred, reason_description, dba_cred['effective_date']))
 
-        if GENERATE_EXTRA_DEMO_CREDS:
-            # DEMO generate a BN credential if the corp has a BN
-            if "bn_9" in corp_info and corp_info["bn_9"] and 0 < len(corp_info["bn_9"]):
-                #print(">>> generate a bn credential for", corp_num, corp_info["bn_9"])
-                bn_cred = {}
-                bn_cred["registration_id"] = self.corp_num_with_prefix(corp_info['corp_typ_cd'], corp_info['corp_num'])
-                bn_cred["business_number"] = corp_info["bn_9"]
-                bn_cred["effective_date"] = corp_info["recognition_dts"]
-                bn_cred["expiry_date"] = ""
-                corp_creds.append(self.build_credential_dict(bn_credential, bn_schema, bn_version, bn_cred['registration_id'], bn_cred, '', bn_cred['effective_date']))
+        # generate a BN credential if the corp has a BN
+        if "bn_9" in corp_info and corp_info["bn_9"] and 0 < len(corp_info["bn_9"]):
+            #print(">>> generate a bn credential for", corp_num, corp_info["bn_9"])
+            bn_cred = {}
+            bn_cred["registration_id"] = self.corp_num_with_prefix(corp_info['corp_typ_cd'], corp_info['corp_num'])
+            bn_cred["business_number"] = corp_info["bn_9"]
+            bn_cred["effective_date"] = corp_info["recognition_dts"]
+            bn_cred["expiry_date"] = ""
+            corp_creds.append(self.build_credential_dict(bn_credential, bn_schema, bn_version, bn_cred['registration_id'], bn_cred, '', bn_cred['effective_date']))
 
+        if GENERATE_EXTRA_DEMO_CREDS:
             # DEMO generate Verified Individual credentials and relationships (2 way)
             vi_party_types = {"DIR":"Director", "OFF":"Officer", "FIO":"Firm Owner",}
             if 'parties' in corp_info and 0 < len(corp_info['parties']):

--- a/data-pipeline/bcreg/find-un-bned-corps.py
+++ b/data-pipeline/bcreg/find-un-bned-corps.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python
+import psycopg2
+import datetime
+import json
+import decimal
+import os 
+import logging
+
+from bcreg.config import config
+from bcreg.bcregistries import system_type
+from bcreg.eventprocessor import EventProcessor, CORP_TYPES_IN_SCOPE, bn_credential
+from bcreg.rocketchat_hooks import log_error, log_warning, log_info
+
+LOG_LEVEL = os.environ.get('LOG_LEVEL', 'WARNING').upper()
+logging.basicConfig(level=LOG_LEVEL)
+
+
+try:
+    with EventProcessor() as event_processor:
+        event_processor.queue_reprocess_credential_type(system_type, bn_credential)
+except Exception as e:
+    print("Exception", e)
+    log_error("find-un-bned-corps processing exception: " + str(e))
+    raise
+
+

--- a/data-pipeline/bcreg/find-un-bned-corps.py
+++ b/data-pipeline/bcreg/find-un-bned-corps.py
@@ -8,7 +8,7 @@ import logging
 
 from bcreg.config import config
 from bcreg.bcregistries import system_type
-from bcreg.eventprocessor import EventProcessor, CORP_TYPES_IN_SCOPE, bn_credential
+from bcreg.eventprocessor import EventProcessor, bn_credential
 from bcreg.rocketchat_hooks import log_error, log_warning, log_info
 
 LOG_LEVEL = os.environ.get('LOG_LEVEL', 'WARNING').upper()

--- a/data-pipeline/bcreg/process-corps-generate-bn-creds.py
+++ b/data-pipeline/bcreg/process-corps-generate-bn-creds.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python
+import psycopg2
+import datetime
+import os
+import logging
+
+from bcreg.config import config
+from bcreg.eventprocessor import EventProcessor
+from bcreg.bcregistries import BCRegistries, system_type
+from bcreg.eventprocessor import EventProcessor, bn_credential
+from bcreg.rocketchat_hooks import log_error, log_warning, log_info
+
+LOG_LEVEL = os.environ.get('LOG_LEVEL', 'WARNING').upper()
+logging.basicConfig(level=LOG_LEVEL)
+
+
+try:
+    with EventProcessor() as event_processor:
+        event_processor.generate_credential_type(system_type, bn_credential)
+except Exception as e:
+    print("Exception", e)
+    log_error("process-corps-generate-bn-creds processing exception: " + str(e))
+    raise


### PR DESCRIPTION
Will require a new schema and credential definition on the Sovrin live network

There is a new script that will stage BN credentials for all existing orgs:

`./run-step.sh bcreg/bc_reg_bn_cred_pipeline.py`

(note that the regular cron job should be stopped during this step)

This runs two steps:

- queues up orgs in a new database table (all existing orgs)
- for each org, stages a new BN credential based on the most recent data from bc_registries (does *not* re-query bc_registries database)

The new BN creds must be posted using either the one-time `./run-step.sh bcreg/bc_reg_pipeline_post_credentials.py` job, or the queue will be drained naturally by the regular cron job.
