### PR TITLE
Remove mime-type from issued credential attributes

### DIFF
--- a/bcreg-aca/src/issuer.py
+++ b/bcreg-aca/src/issuer.py
@@ -890,7 +890,6 @@ def handle_send_credential(cred_input):
         for attribute in credential["attributes"]:
             credential_attributes.append({
                 "name": attribute,
-                "mime-type": "text/plain",
                 "value": credential["attributes"][attribute]
                 })
         cred_offer = {


### PR DESCRIPTION
Signed-off-by: Ian Costanzo <ian@anon-solutions.ca>

Specifying a mime-type results in an extra wallet record *per credential* to store the mime types

This is not necessary, we are not using mime types, and all our attributes are text anyways
