### PR TITLE
Make sure organizations are processed in the correct queue (COLIN vs LEAR)

### DIFF
--- a/data-pipeline/bcreg/bcreg_core.py
+++ b/data-pipeline/bcreg/bcreg_core.py
@@ -285,7 +285,7 @@ class BCReg_Core:
             cache_cursor = None
 
     # cache data from bc registries database into a local in-mem sqlite table
-    # create the table if nencessary, based on the bc registries dictionary
+    # create the table if necessary, based on the bc registries dictionary
     # note: "generate_individual_sql" will generate and print sql statements if True
     #       to be used to generate sample data for unit testing
     def cache_bcreg_data(self, table, desc, rows, generate_individual_sql=False, use_sec=False):

--- a/data-pipeline/bcreg/find-test-corps.py
+++ b/data-pipeline/bcreg/find-test-corps.py
@@ -255,8 +255,8 @@ with BCRegistries() as bc_registries:
         # get specific test corps (there are about 6)
         print("Get specific corps")
         corps = bc_registries.get_specific_corps(specific_corps)
-        corps_2 = bc_registries.get_specific_corps(specific_corps_2)
-        corps.extend(corps_2)
+        #corps_2 = bc_registries.get_specific_corps(specific_corps_2)
+        #corps.extend(corps_2)
 
         print("Find unprocessed events for each corp")
         last_event_dt = bc_registries.get_event_effective_date(prev_event_id)


### PR DESCRIPTION
When processing organizations in one of the queues (COLIN or LEAR) there is a check that any relationships trigger an update of the related org as well.  This fix ensures that the related org gets processed in the correct queue.

See https://github.com/bcgov/aries-vcr/issues/779
