### PR TITLE
Update run-step.sh to use a lock file.

### DIFF
--- a/data-pipeline/scripts/run-step.sh
+++ b/data-pipeline/scripts/run-step.sh
@@ -1,3 +1,18 @@
-# PYTHONPATH=../:. python3 "$@"
-cd .. && PYTHONPATH=. python3 "$@" && cd scripts
+#!/bin/bash
+pushd .. >/dev/null
 
+# Use flock to get a non-blocking lock on a lockfile while a given pipeline is running
+# to avoid multiple instances of the same pipeline from running.
+# The lock files are purposely NOT deleted to avoid possible race conditions.
+lockFileName=./$(basename "${@%%.*}").lock
+(
+    if ! flock -n 200; then
+        echo "Another instance of ${@} is already running. Exiting." >&2
+        exit 1
+    fi
+
+    # Run the requested pipeline
+    PYTHONPATH=. python3 "$@"
+) 200>|"${lockFileName}"
+
+popd >/dev/null


### PR DESCRIPTION
- Dynamically generate a lock file based on the pipeline being run.
  - This ensures different pipelines don't block each other, just themselves.
- Exist if an instance of the pipeline is already running.

This stops multiple instances of each pipeline from starting if an instance is already running.  This happens mostly with the LEAR pipeline when there are a lot of records to process.  The pipeline can take longer to run than the cron period which caused additional instances of the pipelines to run.